### PR TITLE
feat: always-visible action buttons with permission-aware disabled tooltips

### DIFF
--- a/src/app/[daoId]/[proposalId]/page.tsx
+++ b/src/app/[daoId]/[proposalId]/page.tsx
@@ -9,7 +9,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ProposalCard } from "@/components/ProposalCard";
 import { SiteHeader, SiteFooter } from "@/components/Chrome";
 import { useProposal, usePolicy } from "@/hooks/useDao";
-import { getUserRoles } from "@/lib/sputnik";
 
 export default function ProposalDetailPage() {
   const params = useParams<{ daoId: string; proposalId: string }>();
@@ -26,13 +25,7 @@ export default function ProposalDetailPage() {
 
   const proposalQ = useProposal(daoId, validId ? proposalId : -1);
   const policyQ = usePolicy(daoId);
-  const policy = policyQ.data?.result;
-
-  const userRoles =
-    connectedAccountId && policy
-      ? getUserRoles(policy, connectedAccountId)
-      : [];
-  const canVote = connectedAccountId !== null && userRoles.length > 0;
+  const policy = policyQ.data?.result ?? null;
 
   const proposal = proposalQ.data?.result;
 
@@ -80,7 +73,7 @@ export default function ProposalDetailPage() {
             daoId={daoId}
             proposal={proposal}
             connectedAccount={connectedAccountId}
-            canVote={canVote}
+            policy={policy}
             detailed
           />
         )}

--- a/src/app/[daoId]/page.tsx
+++ b/src/app/[daoId]/page.tsx
@@ -9,7 +9,7 @@ import { ProposalList } from "@/components/ProposalList";
 import { CreateProposal } from "@/components/CreateProposal";
 import { SiteHeader, SiteFooter } from "@/components/Chrome";
 import { usePolicy } from "@/hooks/useDao";
-import { getUserRoles } from "@/lib/sputnik";
+import { canAddAnyProposal, getUserRoles } from "@/lib/sputnik";
 import { addRecentDao } from "@/lib/recentDaos";
 
 export default function DaoPage() {
@@ -27,17 +27,25 @@ export default function DaoPage() {
     : null;
 
   const policyQ = usePolicy(daoId);
-  const policy = policyQ.data?.result;
+  const policy = policyQ.data?.result ?? null;
 
-  const userRoles = connectedAccountId && policy
-    ? getUserRoles(policy, connectedAccountId)
-    : [];
+  const userRoles =
+    connectedAccountId && policy
+      ? getUserRoles(policy, connectedAccountId)
+      : [];
 
-  const isMember =
-    connectedAccountId !== null &&
-    userRoles.some((r) => r !== "all" && r.toLowerCase() !== "everyone");
+  const canCreate =
+    !!connectedAccountId &&
+    !!policy &&
+    canAddAnyProposal(policy, connectedAccountId);
 
-  const canVote = connectedAccountId !== null && userRoles.length > 0;
+  const createDisabledTooltip = !connectedAccountId
+    ? "Connect your wallet to create proposals."
+    : !policy
+      ? "Loading DAO policy…"
+      : !canCreate
+        ? `${connectedAccountId} isn't in a role with permission to create proposals in this DAO. Sign in as a voting member.`
+        : null;
 
   return (
     <div className="flex min-h-screen flex-col bg-muted/40 w-full">
@@ -63,7 +71,7 @@ export default function DaoPage() {
           <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border bg-card p-4">
             <div className="text-sm">
               {connectedAccountId ? (
-                canVote ? (
+                userRoles.length > 0 ? (
                   <>
                     Signed in as{" "}
                     <span className="font-medium">{connectedAccountId}</span> ·
@@ -76,7 +84,7 @@ export default function DaoPage() {
                   <>
                     <span className="font-medium">{connectedAccountId}</span>{" "}
                     is not a member of this DAO. You can view proposals but
-                    cannot vote.
+                    cannot vote or create them.
                   </>
                 )
               ) : (
@@ -84,20 +92,20 @@ export default function DaoPage() {
               )}
             </div>
 
-            {connectedAccountId && isMember && (
-              <CreateProposal
-                daoId={daoId}
-                proposalBondYocto={policy.proposal_bond}
-                policy={policy}
-              />
-            )}
+            <CreateProposal
+              daoId={daoId}
+              proposalBondYocto={policy.proposal_bond}
+              policy={policy}
+              disabled={!canCreate}
+              disabledTooltip={createDisabledTooltip}
+            />
           </div>
         )}
 
         <ProposalList
           daoId={daoId}
           connectedAccount={connectedAccountId}
-          canVote={canVote}
+          policy={policy}
         />
       </main>
 

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -8,6 +8,7 @@ import {
   createMainnetClient,
   NearProvider,
 } from "react-near-ts";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const nearStore = createNearStore({
   networkId: "mainnet",
@@ -23,7 +24,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
       enableSystem
       disableTransitionOnChange
     >
-      <NearProvider nearStore={nearStore}>{children}</NearProvider>
+      <NearProvider nearStore={nearStore}>
+        <TooltipProvider delayDuration={200}>{children}</TooltipProvider>
+      </NearProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/**
+ * A button that can be disabled with a tooltip explaining why. Radix's
+ * TooltipTrigger doesn't receive pointer events from a disabled <button>,
+ * so we wrap it in a focusable <span>.
+ */
+export function ActionButton({
+  children,
+  onClick,
+  disabled,
+  disabledTooltip,
+  size = "sm",
+  variant = "outline",
+  className,
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  disabledTooltip?: string | null;
+  size?: "default" | "sm" | "lg" | "icon";
+  variant?:
+    | "default"
+    | "destructive"
+    | "outline"
+    | "secondary"
+    | "ghost"
+    | "link";
+  className?: string;
+}) {
+  const btn = (
+    <Button
+      size={size}
+      variant={variant}
+      disabled={disabled}
+      onClick={onClick}
+      className={className}
+    >
+      {children}
+    </Button>
+  );
+
+  if (!disabled || !disabledTooltip) return btn;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span tabIndex={0} className="inline-block">
+          {btn}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs text-xs">
+        {disabledTooltip}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/CreateProposal.tsx
+++ b/src/components/CreateProposal.tsx
@@ -23,6 +23,11 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAddProposal, useConfig } from "@/hooks/useDao";
 import { formatNearAmount } from "@/lib/near";
 import type { Policy } from "@/lib/sputnik";
@@ -36,10 +41,14 @@ export function CreateProposal({
   daoId,
   proposalBondYocto,
   policy,
+  disabled = false,
+  disabledTooltip = null,
 }: {
   daoId: string;
   proposalBondYocto: string;
   policy: Policy | null;
+  disabled?: boolean;
+  disabledTooltip?: string | null;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -102,11 +111,32 @@ export function CreateProposal({
     return groups;
   }, [templates]);
 
+  const triggerButton = (
+    <Button size="sm" disabled={disabled}>
+      New proposal
+    </Button>
+  );
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button size="sm">New proposal</Button>
-      </DialogTrigger>
+      {disabled ? (
+        disabledTooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span tabIndex={0} className="inline-block">
+                {triggerButton}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-xs">
+              {disabledTooltip}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          triggerButton
+        )
+      ) : (
+        <DialogTrigger asChild>{triggerButton}</DialogTrigger>
+      )}
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Create proposal</DialogTitle>

--- a/src/components/ProposalCard.tsx
+++ b/src/components/ProposalCard.tsx
@@ -4,18 +4,20 @@ import Link from "next/link";
 import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useActProposal } from "@/hooks/useDao";
 import {
+  canActOnProposalKind,
   proposalKindLabel,
+  type Policy,
   type Proposal,
   type ProposalStatus,
   type VoteValue,
 } from "@/lib/sputnik";
 import { formatTimestampNs, shortenAccount } from "@/lib/near";
 import { ProposalDescription } from "@/components/ProposalDescription";
+import { ActionButton } from "@/components/ActionButton";
 
 export function StatusBadge({ status }: { status: ProposalStatus }) {
   switch (status) {
@@ -66,14 +68,14 @@ export function ProposalCard({
   daoId,
   proposal,
   connectedAccount,
-  canVote,
+  policy,
   detailed = false,
   linkToDetail = false,
 }: {
   daoId: string;
   proposal: Proposal;
   connectedAccount: string | null;
-  canVote: boolean;
+  policy: Policy | null;
   detailed?: boolean;
   linkToDetail?: boolean;
 }) {
@@ -88,6 +90,50 @@ export function ProposalCard({
   const totals = voteTotals(proposal);
   const myVote = connectedAccount ? proposal.votes[connectedAccount] : null;
   const kindName = proposalKindLabel(proposal.kind);
+  const isInProgress = proposal.status === "InProgress";
+
+  type VoteButtonState =
+    | { kind: "hidden" }
+    | { kind: "enabled" }
+    | { kind: "disabled"; tooltip: string };
+
+  const voteButtonState = (action: "VoteApprove" | "VoteReject"): VoteButtonState => {
+    if (myVote) return { kind: "hidden" };
+    if (!isInProgress) {
+      return {
+        kind: "disabled",
+        tooltip: `Voting is closed — this proposal is ${proposal.status}.`,
+      };
+    }
+    if (!connectedAccount) {
+      return {
+        kind: "disabled",
+        tooltip: "Connect your wallet to vote on this proposal.",
+      };
+    }
+    if (!policy) {
+      return { kind: "disabled", tooltip: "Loading DAO policy…" };
+    }
+    const allowed = canActOnProposalKind(
+      policy,
+      connectedAccount,
+      proposal.kind,
+      action,
+    );
+    if (!allowed) {
+      const verb = action === "VoteApprove" ? "approve" : "reject";
+      return {
+        kind: "disabled",
+        tooltip: `Your account isn't in a role with permission to ${verb} ${kindName} proposals in this DAO. Sign in as a voting member to enable this action.`,
+      };
+    }
+    return { kind: "enabled" };
+  };
+
+  const approveState = voteButtonState("VoteApprove");
+  const rejectState = voteButtonState("VoteReject");
+  const showVoteButtons =
+    approveState.kind !== "hidden" || rejectState.kind !== "hidden";
 
   const idLabel = (
     <span className="text-sm font-medium">#{proposal.id}</span>
@@ -192,24 +238,40 @@ export function ProposalCard({
             )}
           </div>
 
-          {proposal.status === "InProgress" && canVote && !myVote && (
+          {showVoteButtons && (
             <div className="flex gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={act.isPending && busy}
-                onClick={() => onVote("VoteApprove")}
-              >
-                Approve
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={act.isPending && busy}
-                onClick={() => onVote("VoteReject")}
-              >
-                Reject
-              </Button>
+              {approveState.kind !== "hidden" && (
+                <ActionButton
+                  onClick={() => onVote("VoteApprove")}
+                  disabled={
+                    approveState.kind === "disabled" ||
+                    (act.isPending && busy)
+                  }
+                  disabledTooltip={
+                    approveState.kind === "disabled"
+                      ? approveState.tooltip
+                      : null
+                  }
+                >
+                  Approve
+                </ActionButton>
+              )}
+              {rejectState.kind !== "hidden" && (
+                <ActionButton
+                  onClick={() => onVote("VoteReject")}
+                  disabled={
+                    rejectState.kind === "disabled" ||
+                    (act.isPending && busy)
+                  }
+                  disabledTooltip={
+                    rejectState.kind === "disabled"
+                      ? rejectState.tooltip
+                      : null
+                  }
+                >
+                  Reject
+                </ActionButton>
+              )}
             </div>
           )}
         </div>

--- a/src/components/ProposalList.tsx
+++ b/src/components/ProposalList.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useProposals, useLastProposalId } from "@/hooks/useDao";
 import { ProposalCard } from "@/components/ProposalCard";
+import type { Policy } from "@/lib/sputnik";
 
 const PAGE_SIZE = 25;
 
@@ -27,11 +28,11 @@ function ProposalRowSkeleton() {
 export function ProposalList({
   daoId,
   connectedAccount,
-  canVote,
+  policy,
 }: {
   daoId: string;
   connectedAccount: string | null;
-  canVote: boolean;
+  policy: Policy | null;
 }) {
   const [pageStart, setPageStart] = useState(0);
 
@@ -97,7 +98,7 @@ export function ProposalList({
               daoId={daoId}
               proposal={p}
               connectedAccount={connectedAccount}
-              canVote={canVote}
+              policy={policy}
               linkToDetail
             />
           ))}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-xl bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-lg data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=left]:translate-x-[-1.5px] data-[side=right]:translate-x-[1.5px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/src/lib/sputnik.ts
+++ b/src/lib/sputnik.ts
@@ -85,3 +85,95 @@ export function getUserRoles(policy: Policy, accountId: string): string[] {
   }
   return roles;
 }
+
+// Map a ProposalKind JSON variant to the policy label the contract uses in
+// permission strings (matches ProposalKind::to_policy_label in sputnikdao2).
+const POLICY_LABELS: Record<string, string> = {
+  ChangeConfig: "config",
+  ChangePolicy: "policy",
+  AddMemberToRole: "add_member_to_role",
+  RemoveMemberFromRole: "remove_member_from_role",
+  FunctionCall: "call",
+  UpgradeSelf: "upgrade_self",
+  UpgradeRemote: "upgrade_remote",
+  Transfer: "transfer",
+  SetStakingContract: "set_vote_token",
+  AddBounty: "add_bounty",
+  BountyDone: "bounty_done",
+  Vote: "vote",
+  FactoryInfoUpdate: "factory_info_update",
+  ChangePolicyAddOrUpdateRole: "policy_add_or_update_role",
+  ChangePolicyRemoveRole: "policy_remove_role",
+  ChangePolicyUpdateDefaultVotePolicy: "policy_update_default_vote_policy",
+  ChangePolicyUpdateParameters: "policy_update_parameters",
+};
+
+export function proposalKindPolicyLabel(kind: unknown): string | null {
+  const variant = proposalKindLabel(kind);
+  return POLICY_LABELS[variant] ?? null;
+}
+
+function roleMatchesUser(
+  role: Policy["roles"][number],
+  accountId: string,
+): boolean {
+  if (role.kind === "Everyone") return true;
+  if (typeof role.kind === "object" && "Group" in role.kind) {
+    return role.kind.Group.includes(accountId);
+  }
+  // Member (balance-weighted) — we can't evaluate without reading the
+  // staking contract, so be conservative and treat as no-match.
+  return false;
+}
+
+function roleAllows(
+  role: Policy["roles"][number],
+  kindLabel: string,
+  action: string,
+): boolean {
+  const p = role.permissions;
+  return (
+    p.includes(`${kindLabel}:${action}`) ||
+    p.includes(`${kindLabel}:*`) ||
+    p.includes(`*:${action}`) ||
+    p.includes("*:*")
+  );
+}
+
+export type PolicyAction =
+  | "AddProposal"
+  | "VoteApprove"
+  | "VoteReject"
+  | "VoteRemove";
+
+export function canActOnProposalKind(
+  policy: Policy,
+  accountId: string | null,
+  kind: unknown,
+  action: PolicyAction,
+): boolean {
+  if (!accountId) return false;
+  const kindLabel = proposalKindPolicyLabel(kind);
+  if (!kindLabel) return false;
+  return policy.roles.some(
+    (role) =>
+      roleMatchesUser(role, accountId) && roleAllows(role, kindLabel, action),
+  );
+}
+
+export function canAddAnyProposal(
+  policy: Policy,
+  accountId: string | null,
+): boolean {
+  if (!accountId) return false;
+  return policy.roles.some((role) => {
+    if (!roleMatchesUser(role, accountId)) return false;
+    return role.permissions.some(
+      (p) =>
+        p === "*:*" ||
+        p === "*:AddProposal" ||
+        p.endsWith(":AddProposal") ||
+        p.endsWith(":*"),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- **Approve / Reject** buttons now render on every proposal row (list + detail) and stay visible even when the viewer can't vote. They're disabled — with a Radix Tooltip that explains why and suggests the next step — when the proposal isn't in \`InProgress\`, no wallet is connected, or the connected account doesn't have a role with \`<kind>:VoteApprove\` / \`<kind>:VoteReject\` (per-action, not per-role).
- **New proposal** button is now always shown and disabled with a tooltip when the user isn't signed in or isn't in a role with \`AddProposal\` permission.
- Permission checks mirror the contract's \`can_execute_action\`: new \`canActOnProposalKind\` / \`canAddAnyProposal\` helpers in \`src/lib/sputnik.ts\` walk roles the user matches (\`Everyone\` / \`Group\`) and check for \`<kind>:<Action>\`, \`<kind>:*\`, \`*:<Action>\`, or \`*:*\` permissions. A \`proposalKindPolicyLabel\` map covers every variant (\`FunctionCall\` → \`call\`, \`ChangeConfig\` → \`config\`, etc.).

## Tooltip wording (concrete next steps)

| State | Copy |
| --- | --- |
| Proposal not \`InProgress\` | \`Voting is closed — this proposal is {status}.\` |
| No wallet connected (Approve/Reject) | \`Connect your wallet to vote on this proposal.\` |
| Connected, no permission (Approve) | \`Your account isn't in a role with permission to approve {kind} proposals in this DAO. Sign in as a voting member to enable this action.\` |
| Connected, no permission (Reject) | \`Your account isn't in a role with permission to reject {kind} proposals in this DAO. Sign in as a voting member to enable this action.\` |
| Policy still loading | \`Loading DAO policy…\` |
| No wallet connected (New proposal) | \`Connect your wallet to create proposals.\` |
| Connected, no AddProposal permission | \`{account} isn't in a role with permission to create proposals in this DAO. Sign in as a voting member.\` |

## Implementation notes

- Radix's \`TooltipTrigger\` doesn't receive pointer events from a native \`<button disabled>\`, so a new \`ActionButton\` wraps the disabled case in a focusable \`<span tabIndex={0}>\`. Hover and keyboard focus both open the tooltip.
- \`ProposalCard\` now takes \`policy: Policy | null\` instead of a boolean \`canVote\`. Each button's state is resolved independently — Sputnik roles can grant \`VoteApprove\` without \`VoteReject\` — via a small \`VoteButtonState\` discriminated union (\`hidden\` when the viewer already voted, \`disabled\` + tooltip for each blocker, \`enabled\`).
- \`CreateProposal\` accepts optional \`disabled\` + \`disabledTooltip\` props and renders the trigger outside \`<DialogTrigger>\` when disabled, so the dialog cannot open without permission (the tooltip still shows on hover).
- \`<TooltipProvider delayDuration={200}>\` wraps the tree inside \`<NearProvider>\`.

## Test plan

- [x] \`pnpm lint\` and \`pnpm build\` green
- [x] Verified against \`testing-astradao.sputnik-dao.near\`:
  - Proposal #621 (Rejected): Approve/Reject visible but disabled; focus → \"Voting is closed — this proposal is Rejected.\"
  - Proposal #204 (InProgress, wallet disconnected): buttons disabled; focus → \"Connect your wallet to vote on this proposal.\"
  - No wallet: \"New proposal\" disabled; hover → \"Connect your wallet to create proposals.\"
- [x] Permission-denied tooltip shape verified via unit reasoning against the real policy snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)