### PR TITLE
feat: show past-deadline proposals as Expired + make list card fully clickable

### DIFF
--- a/src/components/ProposalCard.tsx
+++ b/src/components/ProposalCard.tsx
@@ -9,6 +9,8 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useActProposal } from "@/hooks/useDao";
 import {
   canActOnProposalKind,
+  effectiveProposalStatus,
+  proposalDeadlineNs,
   proposalKindLabel,
   type Policy,
   type Proposal,
@@ -90,7 +92,13 @@ export function ProposalCard({
   const totals = voteTotals(proposal);
   const myVote = connectedAccount ? proposal.votes[connectedAccount] : null;
   const kindName = proposalKindLabel(proposal.kind);
-  const isInProgress = proposal.status === "InProgress";
+  const effectiveStatus = effectiveProposalStatus(proposal, policy);
+  const isInProgress = effectiveStatus === "InProgress";
+  const deadlineNs = proposalDeadlineNs(proposal, policy);
+  const deadlineLabel =
+    deadlineNs !== null ? formatTimestampNs(deadlineNs.toString()) : null;
+  const awaitingFinalize =
+    proposal.status === "InProgress" && effectiveStatus === "Expired";
 
   type VoteButtonState =
     | { kind: "hidden" }
@@ -100,9 +108,23 @@ export function ProposalCard({
   const voteButtonState = (action: "VoteApprove" | "VoteReject"): VoteButtonState => {
     if (myVote) return { kind: "hidden" };
     if (!isInProgress) {
+      if (effectiveStatus === "Expired" && awaitingFinalize) {
+        return {
+          kind: "disabled",
+          tooltip: deadlineLabel
+            ? `Voting period ended ${deadlineLabel}. This proposal has expired and is waiting for a Finalize call.`
+            : "The voting period has ended. This proposal has expired and is waiting for a Finalize call.",
+        };
+      }
+      if (effectiveStatus === "Expired") {
+        return {
+          kind: "disabled",
+          tooltip: "Voting is closed — this proposal expired.",
+        };
+      }
       return {
         kind: "disabled",
-        tooltip: `Voting is closed — this proposal is ${proposal.status}.`,
+        tooltip: `Voting is closed — this proposal is ${effectiveStatus}.`,
       };
     }
     if (!connectedAccount) {
@@ -135,30 +157,52 @@ export function ProposalCard({
   const showVoteButtons =
     approveState.kind !== "hidden" || rejectState.kind !== "hidden";
 
-  const idLabel = (
+  const idLabel = linkToDetail ? (
+    // "Stretched link" — the ::after overlay covers the whole relative
+    // parent <Card>, making the entire card clickable. Siblings of this
+    // link (badges, buttons, <details>, description links) paint on top
+    // because they come later in DOM order at the same z-index, so their
+    // own click handlers still work.
+    <Link
+      href={`/${daoId}/${proposal.id}`}
+      className="text-sm font-medium hover:underline after:absolute after:inset-0 after:rounded-xl after:content-['']"
+    >
+      #{proposal.id}
+    </Link>
+  ) : (
     <span className="text-sm font-medium">#{proposal.id}</span>
   );
 
   return (
-    <Card>
-      <CardContent className="p-4 space-y-3">
+    <Card
+      className={
+        linkToDetail
+          ? "relative transition-colors hover:bg-muted/40"
+          : undefined
+      }
+    >
+      <CardContent
+        className={
+          (linkToDetail ? "px-4 py-3 " : "p-4 ") + "space-y-3"
+        }
+      >
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 space-y-1">
             <div className="flex items-center gap-2 flex-wrap">
-              {linkToDetail ? (
-                <Link
-                  href={`/${daoId}/${proposal.id}`}
-                  className="hover:underline"
-                >
-                  {idLabel}
-                </Link>
-              ) : (
-                idLabel
-              )}
+              {idLabel}
               <Badge variant="outline" className="text-[10px]">
                 {kindName}
               </Badge>
-              <StatusBadge status={proposal.status} />
+              <StatusBadge status={effectiveStatus} />
+              {awaitingFinalize && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20"
+                  title="On-chain status is still InProgress; the contract flips to Expired once someone calls act_proposal(Finalize)."
+                >
+                  awaiting finalize
+                </Badge>
+              )}
             </div>
             <p className="text-xs text-muted-foreground break-all">
               by{" "}
@@ -166,12 +210,25 @@ export function ProposalCard({
                 {detailed ? proposal.proposer : shortenAccount(proposal.proposer)}
               </span>{" "}
               · {formatTimestampNs(proposal.submission_time)}
+              {detailed && deadlineLabel && (
+                <>
+                  {" · "}
+                  <span>
+                    {isInProgress ? "voting ends " : "voting ended "}
+                    {deadlineLabel}
+                  </span>
+                </>
+              )}
             </p>
           </div>
         </div>
 
         {proposal.description && (
-          <ProposalDescription text={proposal.description} daoId={daoId} />
+          <ProposalDescription
+            text={proposal.description}
+            daoId={daoId}
+            className={linkToDetail ? "relative z-10" : undefined}
+          />
         )}
 
         {detailed ? (
@@ -182,7 +239,11 @@ export function ProposalCard({
             </pre>
           </div>
         ) : (
-          <details className="group">
+          <details
+            className={
+              "group" + (linkToDetail ? " relative z-10 w-fit" : "")
+            }
+          >
             <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
               Details
             </summary>
@@ -239,7 +300,11 @@ export function ProposalCard({
           </div>
 
           {showVoteButtons && (
-            <div className="flex gap-2">
+            <div
+              className={
+                "flex gap-2" + (linkToDetail ? " relative z-10" : "")
+              }
+            >
               {approveState.kind !== "hidden" && (
                 <ActionButton
                   onClick={() => onVote("VoteApprove")}

--- a/src/lib/sputnik.ts
+++ b/src/lib/sputnik.ts
@@ -74,6 +74,55 @@ export function proposalKindLabel(kind: unknown): string {
   return String(kind);
 }
 
+/**
+ * Proposals on-chain remain `InProgress` until someone calls `Finalize` or
+ * a quorum is reached. Once `submission_time + policy.proposal_period` is in
+ * the past, the proposal is effectively expired — vote actions will fail and
+ * the UI should say so. Returns null if we can't evaluate (policy not loaded).
+ */
+export function proposalDeadlineNs(
+  proposal: Proposal,
+  policy: Policy | null,
+): bigint | null {
+  if (!policy) return null;
+  try {
+    return BigInt(proposal.submission_time) + BigInt(policy.proposal_period);
+  } catch {
+    return null;
+  }
+}
+
+export function isProposalPastDeadline(
+  proposal: Proposal,
+  policy: Policy | null,
+  nowMs: number = Date.now(),
+): boolean {
+  const deadline = proposalDeadlineNs(proposal, policy);
+  if (deadline === null) return false;
+  const nowNs = BigInt(nowMs) * BigInt(1_000_000);
+  return nowNs > deadline;
+}
+
+/**
+ * Returns the status the UI should present. Mirrors the contract's own
+ * `Policy::proposal_status` logic: an `InProgress` proposal whose voting
+ * period has elapsed is "Expired" in every user-visible sense — even if the
+ * on-chain status hasn't flipped yet because no one has called `Finalize`.
+ */
+export function effectiveProposalStatus(
+  proposal: Proposal,
+  policy: Policy | null,
+  nowMs: number = Date.now(),
+): ProposalStatus {
+  if (
+    proposal.status === "InProgress" &&
+    isProposalPastDeadline(proposal, policy, nowMs)
+  ) {
+    return "Expired";
+  }
+  return proposal.status;
+}
+
 export function getUserRoles(policy: Policy, accountId: string): string[] {
   const roles: string[] = [];
   for (const role of policy.roles) {


### PR DESCRIPTION
## Summary

Two UX fixes bundled because both land in the same \`ProposalCard\`:

### 1. Treat past-deadline proposals as Expired

Sputnik proposals stay \`InProgress\` on-chain until someone calls \`act_proposal(Finalize)\`. In practice this means any DAO with a long history has a stale tail of \`InProgress\`-but-actually-expired proposals where \`act_proposal(VoteApprove|VoteReject)\` will revert — and the previous UI cheerfully offered the vote buttons.

New helpers in \`src/lib/sputnik.ts\` mirror the contract's own time check (\`submission_time + policy.proposal_period < now\`):
- \`proposalDeadlineNs(proposal, policy) → bigint | null\`
- \`isProposalPastDeadline(proposal, policy, nowMs?)\`
- \`effectiveProposalStatus(proposal, policy, nowMs?)\` — returns \`"Expired"\` when \`InProgress\` + past deadline, otherwise the raw status.

\`ProposalCard\` now:
- Uses \`effectiveProposalStatus\` for the \`StatusBadge\` and for gating the Approve/Reject buttons.
- Adds an amber **\"awaiting finalize\"** badge when the contract still reports \`InProgress\` but the deadline has passed (so users can tell the on-chain transition hasn't happened yet).
- On the detail view, adds \`voting ends <date>\` / \`voting ended <date>\` after the submission line.
- Upgrades the disabled-vote tooltip for this specific case: \"Voting period ended &lt;date&gt;. This proposal has expired and is waiting for a Finalize call.\"

**Verified** against \`testing-astradao.sputnik-dao.near\` proposal #204 (submitted 3/6/2025, \`InProgress\` on-chain, real expiry 3/11/2025 — now renders as Expired + awaiting-finalize).

### 2. Make the whole list-view proposal card clickable

Uses the Bootstrap-style \"stretched link\" pattern: the \`#<id>\` link gets \`after:absolute after:inset-0\`, turning the link's \`::after\` pseudo-element into a transparent overlay across the whole relative \`<Card>\`. Interactive siblings — \`ProposalDescription\` (markdown, with in-proposal \`?id=\` cross-references), the \`<details>\` toggle, and the Approve/Reject \`ActionButton\`s — get \`relative z-10\` so they sit above the overlay and keep their own click behavior.

Hit-tested via \`document.elementFromPoint\`:
- At a card's geometric center → the stretched \`<a>\` (so empty-space clicks navigate to the proposal detail).
- At the Approve button's bbox → the button \`<span>\` (Radix Tooltip wrapper) → the button receives the click.
- Clicking an in-description \`#620\` ref on card #621 still navigates to \`/620\`, not \`/621\`.

Also shrinks list-mode card padding from \`p-4\` → \`px-4 py-3\` per the feedback about extra top/bottom padding. Detail view keeps \`p-4\`.

## Test plan

- [x] \`pnpm lint\`, \`tsc --noEmit\`, \`pnpm build\` clean
- [x] \`testing-astradao.sputnik-dao.near/204\` renders as Expired + awaiting-finalize; vote buttons disabled with the Finalize-aware tooltip (\"Voting period ended 3/11/2025, 6:30:33 AM. This proposal has expired and is waiting for a Finalize call.\")
- [x] \`testing-astradao.sputnik-dao.near\` list: clicking any non-interactive area of a card navigates to its detail page; Approve/Reject and in-description \`#<n>\` refs still work
- [x] Detail view unchanged in behavior; keeps its own \`p-4\` padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)