### PR TITLE
feat: structured wizard for FunctionCall proposals

### DIFF
--- a/src/components/CreateProposal.tsx
+++ b/src/components/CreateProposal.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -28,6 +29,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  FunctionCallWizard,
+  type FunctionCallWizardState,
+  emptyWizardState,
+  kindToWizard,
+  wizardToKind,
+} from "@/components/FunctionCallWizard";
 import { useAddProposal, useConfig } from "@/hooks/useDao";
 import { formatNearAmount } from "@/lib/near";
 import type { Policy } from "@/lib/sputnik";
@@ -36,6 +44,8 @@ import {
   getTemplates,
   type KindTemplateId,
 } from "@/lib/proposalTemplates";
+
+type EditorMode = "wizard" | "json";
 
 export function CreateProposal({
   daoId,
@@ -69,6 +79,16 @@ export function CreateProposal({
   );
   const [parseError, setParseError] = useState<string | null>(null);
 
+  const [mode, setMode] = useState<EditorMode>("wizard");
+  const [wizardState, setWizardState] = useState<FunctionCallWizardState>(
+    () => kindToWizard(template.kind) ?? emptyWizardState(),
+  );
+  const [wizardParseWarning, setWizardParseWarning] = useState<string | null>(
+    null,
+  );
+
+  const isFunctionCall = templateId === "FunctionCall";
+
   const applyTemplate = (id: KindTemplateId) => {
     const t = templates.find((x) => x.id === id);
     if (!t) return;
@@ -76,6 +96,39 @@ export function CreateProposal({
     setDescription(t.description);
     setKindJson(JSON.stringify(t.kind, null, 2));
     setParseError(null);
+    setWizardParseWarning(null);
+    if (id === "FunctionCall") {
+      setWizardState(kindToWizard(t.kind) ?? emptyWizardState());
+      setMode("wizard");
+    }
+  };
+
+  const switchMode = (next: EditorMode) => {
+    if (next === mode) return;
+    if (next === "json") {
+      setKindJson(JSON.stringify(wizardToKind(wizardState), null, 2));
+      setMode("json");
+      setWizardParseWarning(null);
+    } else {
+      // json → wizard: parse current textarea, fall back to existing state
+      try {
+        const parsed = JSON.parse(kindJson);
+        const ws = kindToWizard(parsed);
+        if (ws) {
+          setWizardState(ws);
+          setWizardParseWarning(null);
+        } else {
+          setWizardParseWarning(
+            "Couldn't load the current JSON into the wizard — it doesn't look like a FunctionCall kind. The wizard kept its previous values.",
+          );
+        }
+      } catch {
+        setWizardParseWarning(
+          "Current JSON is invalid — the wizard kept its previous values.",
+        );
+      }
+      setMode("wizard");
+    }
   };
 
   const add = useAddProposal(daoId);
@@ -87,11 +140,15 @@ export function CreateProposal({
 
   const onSubmit = () => {
     let parsed: unknown;
-    try {
-      parsed = JSON.parse(kindJson);
-    } catch (e) {
-      setParseError(`Invalid JSON: ${(e as Error).message}`);
-      return;
+    if (isFunctionCall && mode === "wizard") {
+      parsed = wizardToKind(wizardState);
+    } else {
+      try {
+        parsed = JSON.parse(kindJson);
+      } catch (e) {
+        setParseError(`Invalid JSON: ${(e as Error).message}`);
+        return;
+      }
     }
     if (parsed !== "Vote" && (parsed === null || typeof parsed !== "object")) {
       setParseError(
@@ -194,21 +251,47 @@ export function CreateProposal({
             />
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="kind">Proposal kind (JSON)</Label>
-            <p className="text-xs text-muted-foreground">
-              Edit the JSON below — it becomes the <code>kind</code> field
-              passed to <code>add_proposal</code>. <code>U128</code> amounts are
-              strings in yoctoNEAR; durations are nanoseconds.
-            </p>
-            <Textarea
-              id="kind"
-              className="font-mono text-xs"
-              rows={14}
-              value={kindJson}
-              onChange={(e) => setKindJson(e.target.value)}
-            />
-          </div>
+          {isFunctionCall && (
+            <Tabs
+              value={mode}
+              onValueChange={(v) => switchMode(v as EditorMode)}
+            >
+              <TabsList>
+                <TabsTrigger value="wizard">Wizard</TabsTrigger>
+                <TabsTrigger value="json">Raw JSON</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          )}
+
+          {isFunctionCall && mode === "wizard" ? (
+            <div className="space-y-2">
+              <FunctionCallWizard
+                value={wizardState}
+                onChange={setWizardState}
+              />
+              {wizardParseWarning && (
+                <Alert variant="destructive">
+                  <AlertDescription>{wizardParseWarning}</AlertDescription>
+                </Alert>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <Label htmlFor="kind">Proposal kind (JSON)</Label>
+              <p className="text-xs text-muted-foreground">
+                Edit the JSON below — it becomes the <code>kind</code> field
+                passed to <code>add_proposal</code>. <code>U128</code> amounts
+                are strings in yoctoNEAR; durations are nanoseconds.
+              </p>
+              <Textarea
+                id="kind"
+                className="font-mono text-xs"
+                rows={14}
+                value={kindJson}
+                onChange={(e) => setKindJson(e.target.value)}
+              />
+            </div>
+          )}
 
           {parseError && (
             <Alert variant="destructive">

--- a/src/components/FunctionCallWizard.tsx
+++ b/src/components/FunctionCallWizard.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  base64DecodeUtf8,
+  base64EncodeUtf8,
+  formatGasUnitsAsTGas,
+  formatNearAmount,
+  parseNearToYocto,
+  parseTGasToGasUnits,
+} from "@/lib/near";
+
+export type DepositUnit = "NEAR" | "yoctoNEAR";
+
+export interface WizardAction {
+  method_name: string;
+  args: string; // plaintext; serialized as base64
+  depositAmount: string;
+  depositUnit: DepositUnit;
+  gasTGas: string;
+}
+
+export interface FunctionCallWizardState {
+  receiver_id: string;
+  actions: WizardAction[];
+}
+
+export function emptyWizardAction(): WizardAction {
+  return {
+    method_name: "",
+    args: "",
+    depositAmount: "0",
+    depositUnit: "NEAR",
+    gasTGas: "100",
+  };
+}
+
+export function emptyWizardState(
+  receiver_id = "example.near",
+): FunctionCallWizardState {
+  return { receiver_id, actions: [emptyWizardAction()] };
+}
+
+/**
+ * Serialize wizard state to the JSON shape Sputnik's `ProposalKind::FunctionCall`
+ * expects. Deposit is converted to a yoctoNEAR string, gas to a base-unit
+ * string (1 TGas = 10^12), and `args` is base64-encoded UTF-8 bytes.
+ */
+export function wizardToKind(state: FunctionCallWizardState): unknown {
+  return {
+    FunctionCall: {
+      receiver_id: state.receiver_id,
+      actions: state.actions.map((a) => ({
+        method_name: a.method_name,
+        args: base64EncodeUtf8(a.args),
+        deposit:
+          a.depositUnit === "NEAR"
+            ? parseNearToYocto(a.depositAmount)
+            : a.depositAmount.trim() || "0",
+        gas: parseTGasToGasUnits(a.gasTGas),
+      })),
+    },
+  };
+}
+
+/**
+ * Attempt to parse an arbitrary ProposalKind JSON back into wizard state so
+ * toggling Wizard ↔ Raw JSON can round-trip when the shape is a valid
+ * FunctionCall. Returns null on any mismatch — caller should fall back to
+ * plain JSON editing.
+ */
+export function kindToWizard(
+  kind: unknown,
+): FunctionCallWizardState | null {
+  if (!kind || typeof kind !== "object") return null;
+  const outer = kind as Record<string, unknown>;
+  if (!("FunctionCall" in outer)) return null;
+  const fc = outer.FunctionCall;
+  if (!fc || typeof fc !== "object") return null;
+  const fcObj = fc as Record<string, unknown>;
+  if (typeof fcObj.receiver_id !== "string") return null;
+  if (!Array.isArray(fcObj.actions)) return null;
+
+  const actions: WizardAction[] = [];
+  for (const a of fcObj.actions) {
+    if (!a || typeof a !== "object") return null;
+    const ao = a as Record<string, unknown>;
+    const method_name = typeof ao.method_name === "string" ? ao.method_name : "";
+    const rawArgs = typeof ao.args === "string" ? ao.args : "";
+    const decoded = base64DecodeUtf8(rawArgs);
+    const args = decoded !== null ? decoded : rawArgs;
+    const deposit = typeof ao.deposit === "string" ? ao.deposit : "0";
+    const gas = typeof ao.gas === "string" ? ao.gas : "0";
+    actions.push({
+      method_name,
+      args,
+      depositAmount: deposit,
+      depositUnit: "yoctoNEAR",
+      gasTGas: formatGasUnitsAsTGas(gas),
+    });
+  }
+
+  return { receiver_id: fcObj.receiver_id, actions };
+}
+
+function depositPreview(a: WizardAction): string {
+  const yocto =
+    a.depositUnit === "NEAR"
+      ? parseNearToYocto(a.depositAmount)
+      : a.depositAmount.trim() || "0";
+  if (yocto === "0") return "0 yoctoNEAR";
+  return a.depositUnit === "NEAR"
+    ? `= ${yocto} yoctoNEAR`
+    : `≈ ${formatNearAmount(yocto)} NEAR`;
+}
+
+function gasPreview(gasTGas: string): string {
+  const parsed = parseTGasToGasUnits(gasTGas);
+  return parsed === "0" ? "0 gas units" : `= ${parsed} gas units`;
+}
+
+export function FunctionCallWizard({
+  value,
+  onChange,
+}: {
+  value: FunctionCallWizardState;
+  onChange: (next: FunctionCallWizardState) => void;
+}) {
+  const updateAction = (i: number, patch: Partial<WizardAction>) => {
+    onChange({
+      ...value,
+      actions: value.actions.map((a, idx) =>
+        idx === i ? { ...a, ...patch } : a,
+      ),
+    });
+  };
+
+  const removeAction = (i: number) => {
+    onChange({
+      ...value,
+      actions: value.actions.filter((_, idx) => idx !== i),
+    });
+  };
+
+  const addAction = () => {
+    onChange({ ...value, actions: [...value.actions, emptyWizardAction()] });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="fc-receiver">Receiver account id</Label>
+        <Input
+          id="fc-receiver"
+          placeholder="example.near"
+          value={value.receiver_id}
+          onChange={(e) => onChange({ ...value, receiver_id: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          The contract the DAO will call when this proposal is approved.
+        </p>
+      </div>
+
+      <Separator />
+
+      <div className="flex items-center justify-between">
+        <div>
+          <Label className="text-[13px]">
+            Actions ({value.actions.length})
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            All actions are executed in a single transaction, in order.
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={addAction}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add action
+        </Button>
+      </div>
+
+      <div className="space-y-3">
+        {value.actions.map((action, i) => (
+          <div
+            key={i}
+            className="rounded-lg border bg-muted/20 p-3 space-y-3"
+          >
+            <div className="flex items-center justify-between">
+              <Badge variant="outline" className="text-[10px]">
+                Action #{i + 1}
+              </Badge>
+              {value.actions.length > 1 && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-muted-foreground hover:text-destructive"
+                  onClick={() => removeAction(i)}
+                  aria-label={`Remove action ${i + 1}`}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Remove
+                </Button>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={`fc-method-${i}`}>Method name</Label>
+              <Input
+                id={`fc-method-${i}`}
+                placeholder="method_name"
+                value={action.method_name}
+                onChange={(e) =>
+                  updateAction(i, { method_name: e.target.value })
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={`fc-args-${i}`}>
+                Args (plaintext — base64-encoded on submit)
+              </Label>
+              <Textarea
+                id={`fc-args-${i}`}
+                className="font-mono text-xs"
+                rows={4}
+                placeholder={`{"key": "value"}`}
+                value={action.args}
+                onChange={(e) => updateAction(i, { args: e.target.value })}
+              />
+              <p className="text-xs text-muted-foreground">
+                Usually a JSON object. Will be encoded to{" "}
+                <code className="rounded bg-background px-1 py-0.5 text-[10px]">
+                  base64
+                </code>{" "}
+                when building the proposal.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor={`fc-deposit-${i}`}>Attached deposit</Label>
+                <div className="flex gap-2">
+                  <Input
+                    id={`fc-deposit-${i}`}
+                    inputMode="decimal"
+                    placeholder="0"
+                    value={action.depositAmount}
+                    onChange={(e) =>
+                      updateAction(i, { depositAmount: e.target.value })
+                    }
+                    className="flex-1"
+                  />
+                  <Select
+                    value={action.depositUnit}
+                    onValueChange={(v) =>
+                      updateAction(i, { depositUnit: v as DepositUnit })
+                    }
+                  >
+                    <SelectTrigger className="w-[110px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="NEAR">NEAR</SelectItem>
+                      <SelectItem value="yoctoNEAR">yoctoNEAR</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <p className="text-xs text-muted-foreground font-mono">
+                  {depositPreview(action)}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`fc-gas-${i}`}>Gas</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id={`fc-gas-${i}`}
+                    inputMode="decimal"
+                    placeholder="100"
+                    value={action.gasTGas}
+                    onChange={(e) =>
+                      updateAction(i, { gasTGas: e.target.value })
+                    }
+                    className="flex-1"
+                  />
+                  <span className="text-sm text-muted-foreground">TGas</span>
+                </div>
+                <p className="text-xs text-muted-foreground font-mono">
+                  {gasPreview(action.gasTGas)}
+                </p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/near.ts
+++ b/src/lib/near.ts
@@ -34,3 +34,53 @@ export function formatTimestampNs(ns: string | number): string {
   const ms = Number(nsBig / BigInt(1_000_000));
   return new Date(ms).toLocaleString();
 }
+
+const TGAS_DECIMALS = 12;
+
+export function parseTGasToGasUnits(tgas: string): string {
+  const trimmed = tgas.trim();
+  if (!trimmed) return "0";
+  const [intPart, fracPart = ""] = trimmed.split(".");
+  const paddedFrac = fracPart
+    .padEnd(TGAS_DECIMALS, "0")
+    .slice(0, TGAS_DECIMALS);
+  const combined = (intPart + paddedFrac).replace(/^0+/, "");
+  return combined || "0";
+}
+
+export function formatGasUnitsAsTGas(gasUnits: string, maxFracDigits = 3): string {
+  if (!gasUnits) return "0";
+  const padded = gasUnits.padStart(TGAS_DECIMALS + 1, "0");
+  const intPart =
+    padded.slice(0, padded.length - TGAS_DECIMALS).replace(/^0+/, "") || "0";
+  const fracPart = padded
+    .slice(padded.length - TGAS_DECIMALS)
+    .replace(/0+$/, "");
+  const fracTrimmed = fracPart.slice(0, maxFracDigits);
+  return fracTrimmed ? `${intPart}.${fracTrimmed}` : intPart;
+}
+
+// Browser-safe base64 of arbitrary Unicode text (btoa only accepts Latin-1).
+export function base64EncodeUtf8(text: string): string {
+  if (typeof window === "undefined") {
+    return Buffer.from(text, "utf8").toString("base64");
+  }
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+export function base64DecodeUtf8(b64: string): string | null {
+  try {
+    if (typeof window === "undefined") {
+      return Buffer.from(b64, "base64").toString("utf8");
+    }
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a form-based **Wizard** editor as the default mode when the FunctionCall template is selected in the New Proposal dialog. The Raw JSON editor is still available behind a tab for anyone who wants to hand-edit.

### Why

The raw JSON editor is good for debugging but punishing for day-to-day use:
- \`args\` must be base64-encoded (easy to get wrong for non-ASCII)
- \`deposit\` is a 24-decimal yoctoNEAR string (e.g. \`\"2500000000000000000000000\"\`)
- \`gas\` is in bare gas units (\`\"100000000000000\"\`), not TGas

Treating a FunctionCall proposal as \"fill in a form\" is how it's actually authored in practice; the wizard just makes that the default.

### What's in the wizard

Per action:
- **Method name** — plain text
- **Args** — multiline plaintext; base64-encoded on submit (UTF-8 safe via \`TextEncoder\` → \`btoa\`, so non-ASCII works)
- **Attached deposit** — decimal input + **NEAR / yoctoNEAR** unit select, with a live preview (\`≈ 2.5 NEAR\` / \`= 2500000000000000000000000 yoctoNEAR\`)
- **Gas** — decimal input in **TGas**, with a live \`= 100000000000000 gas units\` preview

Above the action list:
- **Receiver account id** — single input shared across all actions (Sputnik's shape)
- **Add action** / **Remove** — mutable list; \`Actions (N)\` label stays in sync

### Round-trip behavior

- Wizard → Raw JSON: serializes the current state to the exact ProposalKind shape the contract expects (\`deposit\`/\`gas\` as strings, \`args\` as base64).
- Raw JSON → Wizard: parses the textarea back into wizard state if it matches the FunctionCall shape. Deposit defaults to \`yoctoNEAR\` unit on round-trip (since that's what's in the JSON); gas is decoded back to TGas. If the JSON isn't a FunctionCall kind, the wizard keeps its previous values and shows a warning.

### New helpers in \`src/lib/near.ts\`

- \`parseTGasToGasUnits\` / \`formatGasUnitsAsTGas\` — 10¹² scaling, string-safe for the full u64 range (mirrors \`parseNearToYocto\`/\`formatNearAmount\`)
- \`base64EncodeUtf8\` / \`base64DecodeUtf8\` — \`TextEncoder\`/\`atob\` in the browser, \`Buffer\` fallback for SSR

## Test plan

- [x] \`pnpm lint\`, \`tsc --noEmit\`, \`pnpm build\` clean
- [x] Preview verified end-to-end:
  - Filling \`lockup.near\` / \`deposit_and_stake\` / \`{\"pool_account_id\": \"validator.poolv1.near\"}\` / \`2.5 NEAR\` / \`100 TGas\` → \`Raw JSON\` tab shows:
    ```
    { \"FunctionCall\": { \"receiver_id\": \"lockup.near\", \"actions\": [
      { \"method_name\": \"deposit_and_stake\",
        \"args\": \"eyJwb29sX2FjY291bnRfaWQi...\",
        \"deposit\": \"2500000000000000000000000\",
        \"gas\": \"100000000000000\" } ] } }
    ```
  - Switching back to Wizard restores every field (deposit shown as the yoctoNEAR value with a \`≈ 2.5 NEAR\` preview, gas back to \`100\` TGas, args base64-decoded).
  - \"Add action\" adds a fresh row; \"Remove\" deletes it; \`Actions(N)\` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)