### PR TITLE
feat: decode FunctionCall proposal args from base64 and pretty-print JSON

### DIFF
--- a/src/components/FunctionCallView.tsx
+++ b/src/components/FunctionCallView.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  base64DecodeUtf8,
+  formatGasUnitsAsTGas,
+  formatNearAmount,
+} from "@/lib/near";
+
+interface RawAction {
+  method_name: unknown;
+  args: unknown;
+  deposit: unknown;
+  gas: unknown;
+}
+
+interface RawFunctionCall {
+  receiver_id: unknown;
+  actions: unknown;
+}
+
+export function isFunctionCallKind(
+  kind: unknown,
+): kind is { FunctionCall: RawFunctionCall } {
+  if (!kind || typeof kind !== "object") return false;
+  const outer = kind as Record<string, unknown>;
+  if (!("FunctionCall" in outer)) return false;
+  const fc = outer.FunctionCall;
+  if (!fc || typeof fc !== "object") return false;
+  const fcObj = fc as Record<string, unknown>;
+  return (
+    typeof fcObj.receiver_id === "string" && Array.isArray(fcObj.actions)
+  );
+}
+
+type ArgsDisplay =
+  | { variant: "empty" }
+  | { variant: "json"; pretty: string }
+  | { variant: "text"; text: string; raw: string }
+  | { variant: "binary"; raw: string };
+
+function classifyArgs(raw: unknown): ArgsDisplay {
+  const b64 = typeof raw === "string" ? raw : "";
+  if (!b64) return { variant: "empty" };
+  const decoded = base64DecodeUtf8(b64);
+  if (decoded === null) return { variant: "binary", raw: b64 };
+  try {
+    const parsed = JSON.parse(decoded);
+    return {
+      variant: "json",
+      pretty: JSON.stringify(parsed, null, 2),
+    };
+  } catch {
+    return { variant: "text", text: decoded, raw: b64 };
+  }
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+function ActionView({ action, index }: { action: RawAction; index: number }) {
+  const methodName =
+    typeof action.method_name === "string" ? action.method_name : "";
+  const deposit = typeof action.deposit === "string" ? action.deposit : "0";
+  const gas = typeof action.gas === "string" ? action.gas : "0";
+  const argsDisplay = classifyArgs(action.args);
+  const depositNear = formatNearAmount(deposit);
+  const hasDeposit = deposit !== "0" && deposit !== "";
+  const gasTGas = formatGasUnitsAsTGas(gas);
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-3 space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Badge variant="outline" className="text-[10px]">
+          Action #{index + 1}
+        </Badge>
+        <code className="rounded bg-background px-1.5 py-0.5 text-xs font-mono break-all">
+          {methodName || "(no method)"}
+        </code>
+      </div>
+
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <FieldLabel>args</FieldLabel>
+          {argsDisplay.variant === "json" && (
+            <Badge
+              variant="outline"
+              className="text-[10px] bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-500/20"
+            >
+              JSON
+            </Badge>
+          )}
+          {argsDisplay.variant === "text" && (
+            <Badge
+              variant="outline"
+              className="text-[10px] bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20"
+            >
+              text — not valid JSON
+            </Badge>
+          )}
+          {argsDisplay.variant === "binary" && (
+            <Badge
+              variant="outline"
+              className="text-[10px] bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20"
+            >
+              binary — kept as base64
+            </Badge>
+          )}
+          {argsDisplay.variant === "empty" && (
+            <Badge variant="outline" className="text-[10px]">
+              empty
+            </Badge>
+          )}
+        </div>
+        {argsDisplay.variant === "json" && (
+          <pre className="max-h-64 overflow-auto rounded-md border bg-background p-2 text-[11px] leading-snug">
+            {argsDisplay.pretty}
+          </pre>
+        )}
+        {argsDisplay.variant === "text" && (
+          <>
+            <pre className="max-h-64 overflow-auto rounded-md border bg-background p-2 text-[11px] leading-snug whitespace-pre-wrap break-all">
+              {argsDisplay.text}
+            </pre>
+            <details className="text-[11px] text-muted-foreground">
+              <summary className="cursor-pointer hover:text-foreground">
+                raw base64
+              </summary>
+              <pre className="mt-1 break-all whitespace-pre-wrap font-mono text-[10px]">
+                {argsDisplay.raw}
+              </pre>
+            </details>
+          </>
+        )}
+        {argsDisplay.variant === "binary" && (
+          <pre className="max-h-64 overflow-auto rounded-md border bg-background p-2 text-[10px] leading-snug break-all whitespace-pre-wrap font-mono">
+            {argsDisplay.raw}
+          </pre>
+        )}
+      </div>
+
+      <div className="flex items-center gap-x-4 gap-y-1 flex-wrap text-xs">
+        <div className="flex items-center gap-1.5">
+          <FieldLabel>deposit</FieldLabel>
+          {hasDeposit ? (
+            <span className="font-mono tabular-nums">
+              {depositNear} <span className="text-muted-foreground">NEAR</span>
+            </span>
+          ) : (
+            <span className="text-muted-foreground">0</span>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <FieldLabel>gas</FieldLabel>
+          <span className="font-mono tabular-nums">
+            {gasTGas} <span className="text-muted-foreground">TGas</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FunctionCallView({
+  kind,
+}: {
+  kind: { FunctionCall: RawFunctionCall };
+}) {
+  const fc = kind.FunctionCall;
+  const receiver = typeof fc.receiver_id === "string" ? fc.receiver_id : "";
+  const actions = Array.isArray(fc.actions) ? (fc.actions as RawAction[]) : [];
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 flex-wrap text-xs">
+        <FieldLabel>receiver</FieldLabel>
+        <code className="rounded bg-muted px-1.5 py-0.5 font-mono break-all">
+          {receiver}
+        </code>
+        <span className="text-muted-foreground">
+          · {actions.length} action{actions.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      <div className="space-y-2">
+        {actions.map((a, i) => (
+          <ActionView key={i} action={a} index={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProposalCard.tsx
+++ b/src/components/ProposalCard.tsx
@@ -20,6 +20,10 @@ import {
 import { formatTimestampNs, shortenAccount } from "@/lib/near";
 import { ProposalDescription } from "@/components/ProposalDescription";
 import { ActionButton } from "@/components/ActionButton";
+import {
+  FunctionCallView,
+  isFunctionCallKind,
+} from "@/components/FunctionCallView";
 
 export function StatusBadge({ status }: { status: ProposalStatus }) {
   switch (status) {
@@ -232,24 +236,55 @@ export function ProposalCard({
         )}
 
         {detailed ? (
-          <div className="space-y-1">
-            <p className="text-[13px] font-medium text-muted-foreground">Kind</p>
-            <pre className="max-h-[32rem] overflow-auto rounded-md border bg-muted/30 p-2 text-[11px] leading-snug">
-              {JSON.stringify(proposal.kind, null, 2)}
-            </pre>
+          <div className="space-y-2">
+            <p className="text-[13px] font-medium text-muted-foreground">
+              Kind
+            </p>
+            {isFunctionCallKind(proposal.kind) ? (
+              <>
+                <FunctionCallView kind={proposal.kind} />
+                <details className="group">
+                  <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+                    Raw JSON
+                  </summary>
+                  <pre className="mt-2 max-h-[32rem] overflow-auto rounded-md border bg-muted/30 p-2 text-[11px] leading-snug">
+                    {JSON.stringify(proposal.kind, null, 2)}
+                  </pre>
+                </details>
+              </>
+            ) : (
+              <pre className="max-h-[32rem] overflow-auto rounded-md border bg-muted/30 p-2 text-[11px] leading-snug">
+                {JSON.stringify(proposal.kind, null, 2)}
+              </pre>
+            )}
           </div>
         ) : (
           <details
             className={
-              "group" + (linkToDetail ? " relative z-10 w-fit" : "")
+              "group space-y-2" +
+              (linkToDetail ? " relative z-10" : "")
             }
           >
-            <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+            <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground w-fit">
               Details
             </summary>
-            <pre className="mt-2 max-h-64 overflow-auto rounded-md border bg-muted/30 p-2 text-[11px] leading-snug">
-              {JSON.stringify(proposal.kind, null, 2)}
-            </pre>
+            {isFunctionCallKind(proposal.kind) ? (
+              <div className="pt-2 space-y-2">
+                <FunctionCallView kind={proposal.kind} />
+                <details className="group">
+                  <summary className="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground">
+                    Raw JSON
+                  </summary>
+                  <pre className="mt-2 max-h-64 overflow-auto rounded-md border bg-muted/30 p-2 text-[11px] leading-snug">
+                    {JSON.stringify(proposal.kind, null, 2)}
+                  </pre>
+                </details>
+              </div>
+            ) : (
+              <pre className="mt-2 max-h-64 overflow-auto rounded-md border bg-muted/30 p-2 text-[11px] leading-snug">
+                {JSON.stringify(proposal.kind, null, 2)}
+              </pre>
+            )}
           </details>
         )}
 

--- a/src/lib/near.ts
+++ b/src/lib/near.ts
@@ -48,7 +48,10 @@ export function parseTGasToGasUnits(tgas: string): string {
   return combined || "0";
 }
 
-export function formatGasUnitsAsTGas(gasUnits: string, maxFracDigits = 3): string {
+export function formatGasUnitsAsTGas(
+  gasUnits: string,
+  maxFracDigits = 3,
+): string {
   if (!gasUnits) return "0";
   const padded = gasUnits.padStart(TGAS_DECIMALS + 1, "0");
   const intPart =
@@ -71,15 +74,24 @@ export function base64EncodeUtf8(text: string): string {
   return btoa(binary);
 }
 
+/**
+ * Decode a base64 string to UTF-8 text. Strict: returns null if the input
+ * isn't valid base64 or if the decoded bytes aren't valid UTF-8 (e.g. a
+ * Borsh-serialized binary payload). Callers that want to show FunctionCall
+ * args rely on the null to classify the payload as "binary — kept as
+ * base64"; the wizard's round-trip (kindToWizard) already handles null by
+ * falling back to the raw base64 string.
+ */
 export function base64DecodeUtf8(b64: string): string | null {
   try {
     if (typeof window === "undefined") {
-      return Buffer.from(b64, "base64").toString("utf8");
+      const buf = Buffer.from(b64, "base64");
+      return new TextDecoder("utf-8", { fatal: true }).decode(buf);
     }
     const binary = atob(b64);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-    return new TextDecoder().decode(bytes);
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

FunctionCall proposals used to render as raw \`ProposalKind\` JSON — useful for debugging, unreadable for humans: \`args\` is a base64 blob and \`deposit\`/\`gas\` are in their smallest units (yoctoNEAR / gas units).

This PR adds a structured view that decodes args and humanizes the numeric fields, while keeping a collapsible Raw JSON section right below for developers who want the exact on-chain shape.

## What changes on screen

For **FunctionCall** proposals (both the detail view and the list-view \`Details\` block):

- **RECEIVER** `receiver_id` · N action(s)
- Per action:
  - \`method_name\` as a monospace chip
  - **ARGS** with a status badge + formatted body, one of:

    | variant | when | rendered as |
    | --- | --- | --- |
    | \`JSON\` | base64 decodes to valid UTF-8 and \`JSON.parse\` succeeds | pretty-printed JSON |
    | \`text — not valid JSON\` | decodes to UTF-8 but \`JSON.parse\` throws | raw text, with a \`raw base64\` collapsible fallback |
    | \`binary — kept as base64\` | base64 invalid **or** decoded bytes aren't UTF-8 (e.g. Borsh payloads) | raw base64 string |
    | \`empty\` | \`args === ""\` | just the badge |
  - **DEPOSIT** in NEAR (from yoctoNEAR)
  - **GAS** in TGas (from gas units)

Non-FunctionCall kinds fall back to the existing raw-JSON renderer.

## Implementation notes

- \`src/components/FunctionCallView.tsx\` — the structured renderer and an \`isFunctionCallKind\` type guard.
- \`src/lib/near.ts\`:
  - \`base64DecodeUtf8(b64)\` — uses \`TextDecoder(\"utf-8\", { fatal: true })\`, so non-UTF-8 payloads return \`null\` instead of a garbled string. This is what drives the \`binary — kept as base64\` classification.
  - \`formatGasUnitsAsTGas(gasUnits)\` — mirror of \`formatNearAmount\` but 10¹²-scaled, string-safe across the u64 range.
- \`src/components/ProposalCard.tsx\` — in both detail and list-\`details\` branches, dispatches to \`FunctionCallView\` when \`isFunctionCallKind(proposal.kind)\`, otherwise keeps the raw-JSON \`<pre>\`. Raw JSON is retained as a nested \`<details>\` below the structured view.

## Test plan

- [x] \`pnpm lint\`, \`tsc --noEmit\`, \`pnpm build\` clean
- [x] Verified against \`testing-astradao.sputnik-dao.near\`:
  - **#204** (\`lockup.near::create\`): VestingSchedule args decoded to pretty-printed JSON with the \`JSON\` badge, DEPOSIT **5 NEAR**, GAS **150 TGas**. \`Raw JSON\` collapsible below still available.
  - **#621** (\`bisontrails.poolv1.near::withdraw_all\`): ARGS shows the \`empty\` badge, DEPOSIT 0, GAS **200 TGas**.
  - List view: the \`Details\` disclosure on each card expands to the same structured view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)